### PR TITLE
Add Extended Trigger Time Tag functionality

### DIFF
--- a/src/Digitizer.hh
+++ b/src/Digitizer.hh
@@ -93,6 +93,7 @@ typedef struct DigitizerData {
   float ns_sample;
   uint32_t counters[20];
   uint32_t timetags[20];
+  uint16_t exttimetags[20];
 
   ChannelData channels[16];
 } DigitizerData;

--- a/src/V1730.cc
+++ b/src/V1730.cc
@@ -594,6 +594,7 @@ void V1730Decoder::pack(DigitizerData* ddd, size_t nEvents) {
     memcpy(&data.exttimetags, exttimetags.data(), nEvents*sizeof(uint16_t));
 
     timetags.erase(timetags.begin(), timetags.begin() + nEvents);
+    exttimetags.erase(exttimetags.begin(), exttimetags.begin() + nEvents);
     counters.erase(counters.begin(), counters.begin() + nEvents);
 
     for (size_t i = 0; i < nsamples.size(); i++) {

--- a/src/V1730.hh
+++ b/src/V1730.hh
@@ -94,6 +94,9 @@ typedef struct {
 
     //REG_READOUT_BLT_AGGREGATE_NUMBER
     uint16_t max_board_evt_blt;
+
+    //ETTT_flag
+    uint32_t use_ettt; // 1 bit
     
 } V1730_card_config;
 
@@ -143,6 +146,10 @@ class V1730Settings : public DigitizerSettings {
 
         inline std::string getIndex() {
             return index;
+        }
+
+	inline bool getETTTEnabled() {
+            return card.use_ettt;
         }
     
     protected:
@@ -267,6 +274,7 @@ class V1730Decoder : public Decoder {
         std::vector<size_t> grabbed;
         std::vector<uint16_t*> grabs, patterns;
         std::vector<uint32_t> timetags;
+        std::vector<uint16_t> exttimetags;
         std::vector<uint32_t> counters;
 
         uint32_t* decode_chan_agg(uint32_t *chanagg, uint32_t group, uint16_t pattern);


### PR DESCRIPTION
This PR adds functionality to use the extended trigger time tag for the V1730 in order to have longer between trigger rollover.