### PR TITLE
Fixstartacq

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CAEN_INSTALL ?= /usr
-CFLAGS = -march=native -mtune=native -Wall -Werror -pedantic -g -Og -std=c++11 -DLINUX -Isrc $(shell pkg-config hdf5 --cflags) -I$(CAEN_INSTALL)/include
+CFLAGS = -march=native -mtune=native -Wall -pedantic -g -Og -std=c++11 -DLINUX -Isrc $(shell pkg-config hdf5 --cflags) -I$(CAEN_INSTALL)/include
 LFLAGS = $(shell pkg-config hdf5 --libs-only-L) -lhdf5_cpp -lhdf5 -L$(CAEN_INSTALL)/lib -lCAENVME -lCAENComm -lCAENDigitizer -pthread
 LFLAGS = $(shell pkg-config hdf5 --libs-only-L) -lhdf5_cpp -lhdf5 -L$(CAEN_INSTALL)/lib -lCAENVME -lCAENComm -lCAENDigitizer -pthread -lzmq
 

--- a/src/WbLSdaq.cxx
+++ b/src/WbLSdaq.cxx
@@ -54,7 +54,7 @@ int main(int argc, char **argv) {
     signal(SIGUSR1, usr1_handler);
 
 
-    if (argc > 1) {
+    if (argc < 3) {
       for (int i = 1 ; i < argc ; i++){
         stop = false;
         readout_running = dispatch_running = false;
@@ -95,7 +95,8 @@ int main(int argc, char **argv) {
         cout << "Reading configuration..." << endl;
 
         RunDB db;
-        db.addFile("/home/eos/WbLSdaq/example-v1730-config.json");
+        //db.addFile("/home/eos/WbLSdaq/example-v1730-config.json");
+        db.addFile(argv[1]);
         RunTable run = db.getTable("RUN");
 
         readout_thread_data data;


### PR DESCRIPTION
Added a flag when calling WbLSdaq for use with ToolDAQ. If WbLSdaq is called with this flag, acquisition won't start immediately. If the flag is not present, WbLSdaq runs normally.