### PR TITLE
Fix timetag

### DIFF
--- a/configs/standard_run_diagnostic_water_fill.json
+++ b/configs/standard_run_diagnostic_water_fill.json
@@ -1,7 +1,7 @@
 {
 // Run settings
 name: "RUN",
-outfile: "/home/eos/data/water_fill/fiber_6_6/fiber_6_6-run0",
+outfile: "/home/eos/data/water_fill/diagnostic/dark-rate-test-run-0",
 runtype: "nevents",
 events: 1700,
 repeat_times: 100,

--- a/configs/standard_run_fiber_water_fill.json
+++ b/configs/standard_run_fiber_water_fill.json
@@ -1,15 +1,16 @@
 {
 // Run settings
 name: "RUN",
-run_number: 0,
-outfile: "/home/eos/data/water_fill/fiber_3_1/fiber-3-1-run-0",
+run_number: 4,
+outfile: "/home/eos/data/water_fill/fiber_4_5/fiber-4-5-run-0",
 runtype: "nevents",
 events: 1700,
 repeat_times: 100,
 event_buffer_size: 1000,
 check_temps_every: 100,
 soft_trig: [],
-fiber_number: 31,
+fiber_number: 45,
+fiber_intensity: 1.0,
 run_type: 2
 }
 
@@ -53,7 +54,7 @@ index: "19857",             // To match card to subtables, data storage
 communication: "optical-link-0",  // channel through which to access board
 base_address: 0,         // node # in CONET network
 record_length: 100,     // # of samples per waveform
-post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+post_trigger: 5, // wait this number * 8 samples before freezing current buffer
 buffer_size: 20,                // Readout circular buffer size in MiB
 coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
 global_majority_level: 0,       // this number + 1 requests required for global trigger
@@ -308,7 +309,7 @@ index: "19858",             // To match card to subtables, data storage
 communication: "optical-link-0",  // channel through which to access board
 base_address: 1,         // node # in CONET network
 record_length: 100,     // # of samples per waveform
-post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+post_trigger: 5, // wait this number * 8 samples before freezing current buffer
 buffer_size: 20,                // Readout circular buffer size in MiB
 coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
 global_majority_level: 0,       // this number + 1 requests required for global trigger
@@ -563,7 +564,7 @@ index: "24190",             // To match card to subtables, data storage
 communication: "optical-link-0",  // channel through which to access board
 base_address: 2,         // node # in CONET network
 record_length: 100,     // # of samples per waveform
-post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+post_trigger: 5, // wait this number * 8 samples before freezing current buffer
 buffer_size: 20,                // Readout circular buffer size in MiB
 coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
 global_majority_level: 0,       // this number + 1 requests required for global trigger
@@ -818,7 +819,7 @@ index: "24191",             // To match card to subtables, data storage
 communication: "optical-link-0",  // channel through which to access board
 base_address: 3,         // node # in CONET network
 record_length: 100,     // # of samples per waveform
-post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+post_trigger: 5, // wait this number * 8 samples before freezing current buffer
 buffer_size: 20,                // Readout circular buffer size in MiB
 coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
 global_majority_level: 0,       // this number + 1 requests required for global trigger
@@ -1073,7 +1074,7 @@ index: "24192",             // To match card to subtables, data storage
 communication: "optical-link-0",  // channel through which to access board
 base_address: 4,         // node # in CONET network
 record_length: 100,     // # of samples per waveform
-post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+post_trigger: 5, // wait this number * 8 samples before freezing current buffer
 buffer_size: 20,                // Readout circular buffer size in MiB
 coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
 global_majority_level: 0,       // this number + 1 requests required for global trigger
@@ -1328,7 +1329,7 @@ index: "24193",             // To match card to subtables, data storage
 communication: "optical-link-1",  // channel through which to access board
 base_address: 0,         // node # in CONET network
 record_length: 100,     // # of samples per waveform
-post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+post_trigger: 5, // wait this number * 8 samples before freezing current buffer
 buffer_size: 20,                // Readout circular buffer size in MiB
 coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
 global_majority_level: 0,       // this number + 1 requests required for global trigger
@@ -1583,7 +1584,7 @@ index: "24194",             // To match card to subtables, data storage
 communication: "optical-link-1",  // channel through which to access board
 base_address: 1,         // node # in CONET network
 record_length: 100,     // # of samples per waveform
-post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+post_trigger: 5, // wait this number * 8 samples before freezing current buffer
 buffer_size: 20,                // Readout circular buffer size in MiB
 coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
 global_majority_level: 0,       // this number + 1 requests required for global trigger
@@ -1838,7 +1839,7 @@ index: "24195",             // To match card to subtables, data storage
 communication: "optical-link-1",  // channel through which to access board
 base_address: 2,         // node # in CONET network
 record_length: 100,     // # of samples per waveform
-post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+post_trigger: 5, // wait this number * 8 samples before freezing current buffer
 buffer_size: 20,                // Readout circular buffer size in MiB
 coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
 global_majority_level: 0,       // this number + 1 requests required for global trigger
@@ -2093,7 +2094,7 @@ index: "24196",             // To match card to subtables, data storage
 communication: "optical-link-1",  // channel through which to access board
 base_address: 3,         // node # in CONET network
 record_length: 100,     // # of samples per waveform
-post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+post_trigger: 5, // wait this number * 8 samples before freezing current buffer
 buffer_size: 20,                // Readout circular buffer size in MiB
 coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
 global_majority_level: 0,       // this number + 1 requests required for global trigger
@@ -2348,7 +2349,7 @@ index: "24305",             // To match card to subtables, data storage
 communication: "optical-link-2",  // channel through which to access board
 base_address: 0,         // node # in CONET network
 record_length: 100,     // # of samples per waveform
-post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+post_trigger: 5, // wait this number * 8 samples before freezing current buffer
 buffer_size: 20,                // Readout circular buffer size in MiB
 coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
 global_majority_level: 0,       // this number + 1 requests required for global trigger
@@ -2603,7 +2604,7 @@ index: "24306",             // To match card to subtables, data storage
 communication: "optical-link-2",  // channel through which to access board
 base_address: 1,         // node # in CONET network
 record_length: 100,     // # of samples per waveform
-post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+post_trigger: 5, // wait this number * 8 samples before freezing current buffer
 buffer_size: 20,                // Readout circular buffer size in MiB
 coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
 global_majority_level: 0,       // this number + 1 requests required for global trigger
@@ -2858,7 +2859,7 @@ index: "24307",             // To match card to subtables, data storage
 communication: "optical-link-2",  // channel through which to access board
 base_address: 2,         // node # in CONET network
 record_length: 100,     // # of samples per waveform
-post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+post_trigger: 5, // wait this number * 8 samples before freezing current buffer
 buffer_size: 20,                // Readout circular buffer size in MiB
 coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
 global_majority_level: 0,       // this number + 1 requests required for global trigger
@@ -3113,7 +3114,7 @@ index: "24308",             // To match card to subtables, data storage
 communication: "optical-link-2",  // channel through which to access board
 base_address: 3,         // node # in CONET network
 record_length: 100,     // # of samples per waveform
-post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+post_trigger: 5, // wait this number * 8 samples before freezing current buffer
 buffer_size: 20,                // Readout circular buffer size in MiB
 coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
 global_majority_level: 0,       // this number + 1 requests required for global trigger
@@ -3368,7 +3369,7 @@ index: "24309",             // To match card to subtables, data storage
 communication: "optical-link-3",  // channel through which to access board
 base_address: 0,         // node # in CONET network
 record_length: 100,     // # of samples per waveform
-post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+post_trigger: 5, // wait this number * 8 samples before freezing current buffer
 buffer_size: 20,                // Readout circular buffer size in MiB
 coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
 global_majority_level: 0,       // this number + 1 requests required for global trigger
@@ -3623,7 +3624,7 @@ index: "24310",             // To match card to subtables, data storage
 communication: "optical-link-3",  // channel through which to access board
 base_address: 1,         // node # in CONET network
 record_length: 100,     // # of samples per waveform
-post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+post_trigger: 5, // wait this number * 8 samples before freezing current buffer
 buffer_size: 20,                // Readout circular buffer size in MiB
 coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
 global_majority_level: 0,       // this number + 1 requests required for global trigger
@@ -3878,7 +3879,7 @@ index: "24311",             // To match card to subtables, data storage
 communication: "optical-link-3",  // channel through which to access board
 base_address: 2,         // node # in CONET network
 record_length: 100,     // # of samples per waveform
-post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+post_trigger: 5, // wait this number * 8 samples before freezing current buffer
 buffer_size: 20,                // Readout circular buffer size in MiB
 coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
 global_majority_level: 0,       // this number + 1 requests required for global trigger
@@ -4133,7 +4134,7 @@ index: "24312",             // To match card to subtables, data storage
 communication: "optical-link-3",  // channel through which to access board
 base_address: 3,         // node # in CONET network
 record_length: 100,     // # of samples per waveform
-post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+post_trigger: 5, // wait this number * 8 samples before freezing current buffer
 buffer_size: 20,                // Readout circular buffer size in MiB
 coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
 global_majority_level: 0,       // this number + 1 requests required for global trigger

--- a/configs/standard_run_fiber_water_fill.json
+++ b/configs/standard_run_fiber_water_fill.json
@@ -1,0 +1,4383 @@
+{
+// Run settings
+name: "RUN",
+run_number: 0,
+outfile: "/home/eos/data/water_fill/fiber_3_1/fiber-3-1-run-0",
+runtype: "nevents",
+events: 1700,
+repeat_times: 100,
+event_buffer_size: 1000,
+check_temps_every: 100,
+soft_trig: [],
+fiber_number: 31,
+run_type: 2
+}
+
+{
+name: "Dispatch",
+index: "",
+type: "legacy_hdf5"
+}
+
+{
+name: "Communication",          // defining a communication channel
+index: "optical-link-0",          // ID of communication channel
+type: "CONETNetwork",           // type of channel
+link_num: 0          // link # to use
+}
+
+{
+name: "Communication",          // defining a communication channel
+index: "optical-link-1",          // ID of communication channel
+type: "CONETNetwork",           // type of channel
+link_num: 1          // link # to use
+}
+
+{
+name: "Communication",          // defining a communication channel
+index: "optical-link-2",          // ID of communication channel
+type: "CONETNetwork",           // type of channel
+link_num: 2          // link # to use
+}
+
+{
+name: "Communication",          // defining a communication channel
+index: "optical-link-3",          // ID of communication channel
+type: "CONETNetwork",           // type of channel
+link_num: 3          // link # to use
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "19857",             // To match card to subtables, data storage
+communication: "optical-link-0",  // channel through which to access board
+base_address: 0,         // node # in CONET network
+record_length: 100,     // # of samples per waveform
+post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "19857",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "19857",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "19857",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "19857",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "19857",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "19857",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "19857",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "19857",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "19857",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "19857",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "19857",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "19857",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "19857",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "19857",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "19857",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "19857",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "19857",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "19857",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "19857",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "19857",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "19857",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "19857",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "19857",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "19857",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "19858",             // To match card to subtables, data storage
+communication: "optical-link-0",  // channel through which to access board
+base_address: 1,         // node # in CONET network
+record_length: 100,     // # of samples per waveform
+post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "19858",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "19858",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "19858",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "19858",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "19858",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "19858",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "19858",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "19858",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "19858",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "19858",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "19858",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "19858",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "19858",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "19858",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "19858",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "19858",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "19858",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "19858",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "19858",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "19858",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "19858",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "19858",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "19858",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "19858",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "24190",             // To match card to subtables, data storage
+communication: "optical-link-0",  // channel through which to access board
+base_address: 2,         // node # in CONET network
+record_length: 100,     // # of samples per waveform
+post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "24190",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "24190",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "24190",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "24190",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "24190",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "24190",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "24190",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "24190",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "24190",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "24190",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "24190",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "24190",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "24190",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "24190",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "24190",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "24190",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "24190",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "24190",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "24190",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "24190",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "24190",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "24190",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "24190",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "24190",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "24191",             // To match card to subtables, data storage
+communication: "optical-link-0",  // channel through which to access board
+base_address: 3,         // node # in CONET network
+record_length: 100,     // # of samples per waveform
+post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "24191",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "24191",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "24191",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "24191",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "24191",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "24191",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "24191",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "24191",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "24191",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "24191",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "24191",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "24191",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "24191",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "24191",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "24191",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "24191",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "24191",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "24191",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "24191",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "24191",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "24191",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "24191",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "24191",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "24191",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "24192",             // To match card to subtables, data storage
+communication: "optical-link-0",  // channel through which to access board
+base_address: 4,         // node # in CONET network
+record_length: 100,     // # of samples per waveform
+post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "24192",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "24192",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "24192",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "24192",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "24192",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "24192",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "24192",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "24192",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "24192",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "24192",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "24192",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "24192",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "24192",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "24192",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "24192",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "24192",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "24192",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "24192",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "24192",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "24192",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "24192",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "24192",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "24192",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "24192",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "24193",             // To match card to subtables, data storage
+communication: "optical-link-1",  // channel through which to access board
+base_address: 0,         // node # in CONET network
+record_length: 100,     // # of samples per waveform
+post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "24193",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "24193",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "24193",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "24193",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "24193",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "24193",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "24193",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "24193",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "24193",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "24193",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "24193",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "24193",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "24193",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "24193",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "24193",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "24193",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "24193",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "24193",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "24193",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "24193",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "24193",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "24193",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "24193",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "24193",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "24194",             // To match card to subtables, data storage
+communication: "optical-link-1",  // channel through which to access board
+base_address: 1,         // node # in CONET network
+record_length: 100,     // # of samples per waveform
+post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "24194",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "24194",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "24194",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "24194",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "24194",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "24194",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "24194",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "24194",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "24194",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "24194",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "24194",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "24194",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "24194",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "24194",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "24194",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "24194",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "24194",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "24194",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "24194",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "24194",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "24194",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "24194",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "24194",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "24194",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "24195",             // To match card to subtables, data storage
+communication: "optical-link-1",  // channel through which to access board
+base_address: 2,         // node # in CONET network
+record_length: 100,     // # of samples per waveform
+post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "24195",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "24195",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "24195",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "24195",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "24195",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "24195",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "24195",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "24195",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "24195",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "24195",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "24195",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "24195",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "24195",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "24195",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "24195",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "24195",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "24195",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "24195",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "24195",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "24195",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "24195",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "24195",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "24195",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "24195",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "24196",             // To match card to subtables, data storage
+communication: "optical-link-1",  // channel through which to access board
+base_address: 3,         // node # in CONET network
+record_length: 100,     // # of samples per waveform
+post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "24196",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "24196",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "24196",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "24196",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "24196",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "24196",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "24196",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "24196",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "24196",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "24196",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "24196",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "24196",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "24196",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "24196",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "24196",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "24196",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "24196",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "24196",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "24196",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "24196",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "24196",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "24196",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "24196",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "24196",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "24305",             // To match card to subtables, data storage
+communication: "optical-link-2",  // channel through which to access board
+base_address: 0,         // node # in CONET network
+record_length: 100,     // # of samples per waveform
+post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "24305",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "24305",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "24305",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "24305",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "24305",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "24305",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "24305",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "24305",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "24305",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "24305",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "24305",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "24305",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "24305",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "24305",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "24305",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "24305",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "24305",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "24305",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "24305",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "24305",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "24305",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "24305",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "24305",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "24305",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "24306",             // To match card to subtables, data storage
+communication: "optical-link-2",  // channel through which to access board
+base_address: 1,         // node # in CONET network
+record_length: 100,     // # of samples per waveform
+post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "24306",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "24306",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "24306",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "24306",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "24306",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "24306",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "24306",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "24306",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "24306",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "24306",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "24306",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "24306",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "24306",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "24306",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "24306",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "24306",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "24306",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "24306",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "24306",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "24306",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "24306",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "24306",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "24306",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "24306",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "24307",             // To match card to subtables, data storage
+communication: "optical-link-2",  // channel through which to access board
+base_address: 2,         // node # in CONET network
+record_length: 100,     // # of samples per waveform
+post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "24307",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "24307",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "24307",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "24307",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "24307",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "24307",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "24307",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "24307",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "24307",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "24307",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "24307",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "24307",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "24307",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "24307",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "24307",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "24307",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "24307",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "24307",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "24307",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "24307",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "24307",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "24307",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "24307",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "24307",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "24308",             // To match card to subtables, data storage
+communication: "optical-link-2",  // channel through which to access board
+base_address: 3,         // node # in CONET network
+record_length: 100,     // # of samples per waveform
+post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "24308",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "24308",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "24308",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "24308",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "24308",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "24308",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "24308",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "24308",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "24308",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "24308",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "24308",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "24308",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "24308",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "24308",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "24308",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "24308",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "24308",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "24308",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "24308",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "24308",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "24308",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "24308",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "24308",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "24308",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "24309",             // To match card to subtables, data storage
+communication: "optical-link-3",  // channel through which to access board
+base_address: 0,         // node # in CONET network
+record_length: 100,     // # of samples per waveform
+post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "24309",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "24309",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "24309",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "24309",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "24309",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "24309",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "24309",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "24309",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "24309",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "24309",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "24309",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "24309",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "24309",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "24309",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "24309",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "24309",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "24309",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "24309",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "24309",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "24309",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "24309",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "24309",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "24309",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "24309",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "24310",             // To match card to subtables, data storage
+communication: "optical-link-3",  // channel through which to access board
+base_address: 1,         // node # in CONET network
+record_length: 100,     // # of samples per waveform
+post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "24310",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "24310",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "24310",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "24310",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "24310",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "24310",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "24310",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "24310",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "24310",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "24310",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "24310",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "24310",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "24310",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "24310",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "24310",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "24310",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "24310",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "24310",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "24310",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "24310",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "24310",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "24310",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "24310",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "24310",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "24311",             // To match card to subtables, data storage
+communication: "optical-link-3",  // channel through which to access board
+base_address: 2,         // node # in CONET network
+record_length: 100,     // # of samples per waveform
+post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "24311",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "24311",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "24311",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "24311",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "24311",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "24311",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "24311",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "24311",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "24311",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "24311",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "24311",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "24311",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "24311",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "24311",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "24311",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "24311",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "24311",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "24311",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "24311",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "24311",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "24311",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "24311",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "24311",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "24311",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "24312",             // To match card to subtables, data storage
+communication: "optical-link-3",  // channel through which to access board
+base_address: 3,         // node # in CONET network
+record_length: 100,     // # of samples per waveform
+post_trigger: 12, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "24312",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "24312",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "24312",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "24312",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "24312",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "24312",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "24312",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "24312",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "24312",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "24312",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "24312",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "24312",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "24312",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "24312",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "24312",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "24312",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "24312",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "24312",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "24312",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "24312",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "24312",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "24312",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "24312",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "24312",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}

--- a/configs/standard_run_laserball_water_fill.json
+++ b/configs/standard_run_laserball_water_fill.json
@@ -1,7 +1,7 @@
 {
 // Run settings
 name: "RUN",
-outfile: "/home/eos/data/water_fill/fiber_6_6/fiber_6_6-run0",
+outfile: "/home/eos/data/water_fill/laserball/laserball-run0",
 runtype: "nevents",
 events: 1700,
 repeat_times: 100,

--- a/configs/standard_run_muons_water_fill.json
+++ b/configs/standard_run_muons_water_fill.json
@@ -1,0 +1,4384 @@
+
+{
+// Run settings
+name: "RUN",
+run_number: 0,
+outfile: "/home/eos/data/water_fill/muons1/muons1",
+runtype: "nevents",
+events: 1700,
+repeat_times: 100,
+event_buffer_size: 1000,
+check_temps_every: 100,
+soft_trig: [],
+fiber_number: 0,
+run_type: 0
+}
+
+{
+name: "Dispatch",
+index: "",
+type: "legacy_hdf5"
+}
+
+{
+name: "Communication",          // defining a communication channel
+index: "optical-link-0",          // ID of communication channel
+type: "CONETNetwork",           // type of channel
+link_num: 0          // link # to use
+}
+
+{
+name: "Communication",          // defining a communication channel
+index: "optical-link-1",          // ID of communication channel
+type: "CONETNetwork",           // type of channel
+link_num: 1          // link # to use
+}
+
+{
+name: "Communication",          // defining a communication channel
+index: "optical-link-2",          // ID of communication channel
+type: "CONETNetwork",           // type of channel
+link_num: 2          // link # to use
+}
+
+{
+name: "Communication",          // defining a communication channel
+index: "optical-link-3",          // ID of communication channel
+type: "CONETNetwork",           // type of channel
+link_num: 3          // link # to use
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "19857",             // To match card to subtables, data storage
+communication: "optical-link-0",  // channel through which to access board
+base_address: 0,         // node # in CONET network
+record_length: 150,     // # of samples per waveform
+post_trigger: 2, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "19857",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "19857",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "19857",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "19857",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "19857",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "19857",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "19857",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "19857",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "19857",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "19857",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "19857",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "19857",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "19857",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "19857",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "19857",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "19857",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "19857",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "19857",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "19857",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "19857",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "19857",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "19857",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "19857",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "19857",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "19858",             // To match card to subtables, data storage
+communication: "optical-link-0",  // channel through which to access board
+base_address: 1,         // node # in CONET network
+record_length: 150,     // # of samples per waveform
+post_trigger: 2, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "19858",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "19858",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "19858",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "19858",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "19858",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "19858",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "19858",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "19858",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "19858",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "19858",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "19858",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "19858",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "19858",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "19858",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "19858",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "19858",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "19858",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "19858",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "19858",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "19858",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "19858",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "19858",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "19858",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "19858",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "24190",             // To match card to subtables, data storage
+communication: "optical-link-0",  // channel through which to access board
+base_address: 2,         // node # in CONET network
+record_length: 150,     // # of samples per waveform
+post_trigger: 2, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "24190",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "24190",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "24190",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "24190",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "24190",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "24190",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "24190",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "24190",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "24190",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "24190",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "24190",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "24190",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "24190",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "24190",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "24190",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "24190",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "24190",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "24190",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "24190",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "24190",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "24190",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "24190",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "24190",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "24190",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "24191",             // To match card to subtables, data storage
+communication: "optical-link-0",  // channel through which to access board
+base_address: 3,         // node # in CONET network
+record_length: 150,     // # of samples per waveform
+post_trigger: 2, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "24191",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "24191",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "24191",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "24191",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "24191",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "24191",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "24191",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "24191",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "24191",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "24191",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "24191",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "24191",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "24191",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "24191",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "24191",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "24191",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "24191",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "24191",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "24191",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "24191",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "24191",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "24191",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "24191",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "24191",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "24192",             // To match card to subtables, data storage
+communication: "optical-link-0",  // channel through which to access board
+base_address: 4,         // node # in CONET network
+record_length: 150,     // # of samples per waveform
+post_trigger: 2, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "24192",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "24192",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "24192",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "24192",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "24192",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "24192",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "24192",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "24192",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "24192",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "24192",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "24192",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "24192",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "24192",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "24192",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "24192",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "24192",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "24192",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "24192",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "24192",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "24192",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "24192",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "24192",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "24192",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "24192",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "24193",             // To match card to subtables, data storage
+communication: "optical-link-1",  // channel through which to access board
+base_address: 0,         // node # in CONET network
+record_length: 150,     // # of samples per waveform
+post_trigger: 2, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "24193",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "24193",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "24193",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "24193",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "24193",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "24193",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "24193",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "24193",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "24193",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "24193",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "24193",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "24193",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "24193",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "24193",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "24193",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "24193",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "24193",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "24193",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "24193",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "24193",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "24193",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "24193",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "24193",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "24193",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "24194",             // To match card to subtables, data storage
+communication: "optical-link-1",  // channel through which to access board
+base_address: 1,         // node # in CONET network
+record_length: 150,     // # of samples per waveform
+post_trigger: 2, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "24194",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "24194",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "24194",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "24194",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "24194",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "24194",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "24194",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "24194",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "24194",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "24194",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "24194",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "24194",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "24194",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "24194",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "24194",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "24194",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "24194",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "24194",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "24194",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "24194",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "24194",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "24194",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "24194",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "24194",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "24195",             // To match card to subtables, data storage
+communication: "optical-link-1",  // channel through which to access board
+base_address: 2,         // node # in CONET network
+record_length: 150,     // # of samples per waveform
+post_trigger: 2, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "24195",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "24195",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "24195",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "24195",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "24195",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "24195",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "24195",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "24195",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "24195",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "24195",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "24195",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "24195",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "24195",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "24195",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "24195",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "24195",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "24195",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "24195",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "24195",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "24195",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "24195",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "24195",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "24195",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "24195",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "24196",             // To match card to subtables, data storage
+communication: "optical-link-1",  // channel through which to access board
+base_address: 3,         // node # in CONET network
+record_length: 150,     // # of samples per waveform
+post_trigger: 2, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "24196",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "24196",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "24196",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "24196",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "24196",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "24196",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "24196",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "24196",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "24196",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "24196",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "24196",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "24196",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "24196",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "24196",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "24196",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "24196",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "24196",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "24196",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "24196",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "24196",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "24196",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "24196",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "24196",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "24196",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "24305",             // To match card to subtables, data storage
+communication: "optical-link-2",  // channel through which to access board
+base_address: 0,         // node # in CONET network
+record_length: 150,     // # of samples per waveform
+post_trigger: 2, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "24305",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "24305",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "24305",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "24305",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "24305",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "24305",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "24305",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "24305",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "24305",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "24305",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "24305",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "24305",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "24305",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "24305",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "24305",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "24305",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "24305",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "24305",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "24305",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "24305",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "24305",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "24305",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "24305",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "24305",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "24306",             // To match card to subtables, data storage
+communication: "optical-link-2",  // channel through which to access board
+base_address: 1,         // node # in CONET network
+record_length: 150,     // # of samples per waveform
+post_trigger: 2, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "24306",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "24306",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "24306",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "24306",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "24306",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "24306",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "24306",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "24306",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "24306",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "24306",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "24306",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "24306",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "24306",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "24306",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "24306",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "24306",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "24306",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "24306",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "24306",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "24306",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "24306",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "24306",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "24306",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "24306",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "24307",             // To match card to subtables, data storage
+communication: "optical-link-2",  // channel through which to access board
+base_address: 2,         // node # in CONET network
+record_length: 150,     // # of samples per waveform
+post_trigger: 2, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "24307",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "24307",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "24307",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "24307",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "24307",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "24307",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "24307",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "24307",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "24307",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "24307",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "24307",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "24307",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "24307",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "24307",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "24307",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "24307",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "24307",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "24307",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "24307",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "24307",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "24307",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "24307",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "24307",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "24307",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "24308",             // To match card to subtables, data storage
+communication: "optical-link-2",  // channel through which to access board
+base_address: 3,         // node # in CONET network
+record_length: 150,     // # of samples per waveform
+post_trigger: 2, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "24308",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "24308",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "24308",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "24308",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "24308",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "24308",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "24308",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "24308",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "24308",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "24308",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "24308",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "24308",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "24308",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "24308",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "24308",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "24308",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "24308",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "24308",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "24308",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "24308",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "24308",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "24308",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "24308",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "24308",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "24309",             // To match card to subtables, data storage
+communication: "optical-link-3",  // channel through which to access board
+base_address: 0,         // node # in CONET network
+record_length: 150,     // # of samples per waveform
+post_trigger: 2, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "24309",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "24309",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "24309",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "24309",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "24309",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "24309",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "24309",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "24309",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "24309",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "24309",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "24309",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "24309",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "24309",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "24309",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "24309",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "24309",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "24309",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "24309",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "24309",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "24309",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "24309",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "24309",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "24309",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "24309",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "24310",             // To match card to subtables, data storage
+communication: "optical-link-3",  // channel through which to access board
+base_address: 1,         // node # in CONET network
+record_length: 150,     // # of samples per waveform
+post_trigger: 2, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "24310",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "24310",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "24310",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "24310",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "24310",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "24310",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "24310",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "24310",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "24310",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "24310",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "24310",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "24310",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "24310",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "24310",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "24310",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "24310",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "24310",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "24310",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "24310",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "24310",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "24310",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "24310",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "24310",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "24310",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "24311",             // To match card to subtables, data storage
+communication: "optical-link-3",  // channel through which to access board
+base_address: 2,         // node # in CONET network
+record_length: 150,     // # of samples per waveform
+post_trigger: 2, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "24311",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "24311",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "24311",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "24311",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "24311",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "24311",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "24311",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "24311",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "24311",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "24311",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "24311",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "24311",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "24311",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "24311",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "24311",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "24311",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "24311",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "24311",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "24311",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "24311",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "24311",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "24311",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "24311",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "24311",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "V1730",                  // V1730 global settings
+index: "24312",             // To match card to subtables, data storage
+communication: "optical-link-3",  // channel through which to access board
+base_address: 3,         // node # in CONET network
+record_length: 150,     // # of samples per waveform
+post_trigger: 2, // wait this number * 8 samples before freezing current buffer
+buffer_size: 20,                // Readout circular buffer size in MiB
+coincidence_window: 0,          // time window for majority coincidence is this number * 8 ns
+global_majority_level: 0,       // this number + 1 requests required for global trigger
+external_trigger_enable: true,  // trig in fires a global trigger
+external_trigger_out: false,     // route trig in to trig out
+software_trigger_enable: false, // software trigger fires a global trigger
+software_trigger_out: false,    // route software trigger to trig out
+trig_out_logic: 0,              // Choose index [OR, AND, MAJORITY] how trigger requests fire trig out
+trig_out_majority_level: 0,     // trig_out_majority_level+1 requests required for trig out in MAJORITY mode
+trigger_overlap: 0,             // overlapping trigger windows [DISABLED, ENABLED]
+test_pattern: 0,                // triangular wave test pattern [DISABLED, ENABLED]
+trigger_polarity: 0,            // trigger on pulse going [OVER, UNDER] threshold
+events_per_transfer: 0x3FF, // maximum board aggregates to read out during a single transfer
+use_ettt: true,                 // Use the additional timing bits
+}
+
+{
+name: "GR0",              // pairwise common settings
+index: "24312",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH0",            // for channel 0
+index: "24312",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH1",            // for channel 0
+index: "24312",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR1",              // pairwise common settings
+index: "24312",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH2",            // for channel 0
+index: "24312",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH3",            // for channel 0
+index: "24312",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR2",              // pairwise common settings
+index: "24312",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH4",            // for channel 0
+index: "24312",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH5",            // for channel 0
+index: "24312",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR3",              // pairwise common settings
+index: "24312",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH6",            // for channel 0
+index: "24312",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH7",            // for channel 0
+index: "24312",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR4",              // pairwise common settings
+index: "24312",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH8",            // for channel 0
+index: "24312",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH9",            // for channel 0
+index: "24312",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR5",              // pairwise common settings
+index: "24312",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH10",            // for channel 0
+index: "24312",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH11",            // for channel 0
+index: "24312",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR6",              // pairwise common settings
+index: "24312",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH12",            // for channel 0
+index: "24312",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH13",            // for channel 0
+index: "24312",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "GR7",              // pairwise common settings
+index: "24312",             // channel specific settings
+local_logic: 3,   // what to propagate as trigger requests [AND, EVEN, ODD, OR]
+request_duration: 0, // trigger request pulse duration [fixed width, over/under threshold]
+request_global_trigger: false, // send global trigger request on local trigger
+request_trig_out: false,        // send trigger out request on local trigger
+}
+
+{
+name: "CH14",            // for channel 0
+index: "24312",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}
+
+{
+name: "CH15",            // for channel 0
+index: "24312",             // channel specific settings
+enabled: true,           // record events from this channel
+dc_offset: 9829,       // volts to shift the input by (-1V to 1V)
+trigger_threshold: 13926, // counts past baseline to trigger
+shaped_trigger_width: 1,       // analog sum pulse width is this number times 8 ns
+dynamic_range: 0, // Choose index [2Vpp,0.5Vpp]
+}

--- a/src/Decode.hh
+++ b/src/Decode.hh
@@ -63,7 +63,6 @@ void *decode_thread(void *_data) {
                 Exception::dontPrint();
                 
                 string fname = data->runtype->fname() + ".h5"; 
-                cout << "Saving data to " << fname << endl;
                 
                 H5File file(fname, H5F_ACC_TRUNC);
                 data->runtype->write(file);

--- a/src/Dispatch.hh
+++ b/src/Dispatch.hh
@@ -44,6 +44,7 @@ void *dispatch_thread(void *_data) {
 
     vector<size_t> evtsReady(data->buffers->size());
     data->runtype->begin();
+    bool print = false; 
     try {
         dispatch_running = true;
         while (dispatch_running) {
@@ -56,15 +57,14 @@ void *dispatch_thread(void *_data) {
                 if (found) break;
                 pthread_cond_wait(data->newdata,data->iomutex);
             }
-            
+
             size_t total = data->dispatcher->Digest(*data->buffers);
+            string path = data->dispatcher->NextPath();
             if (stop && total == 0) {
                 dispatch_running = false;
-            } else if (stop || data->dispatcher->Ready()) {
+            } else if (stop || data->dispatcher->Ready(print, path)) {
                 Exception::dontPrint();
 
-                string path = data->dispatcher->NextPath();
-                cout << "Streaming data to " << path << endl;
                 data->dispatcher->Dispatch(*data->buffers);
                 dispatch_running = data->runtype->keepgoing();
             }

--- a/src/Dispatcher.cc
+++ b/src/Dispatcher.cc
@@ -16,24 +16,28 @@ Dispatcher::~Dispatcher(){
     /* */
 }
 
-bool Dispatcher::Ready(){
+bool Dispatcher::Ready(bool &print, string path){
     double rate = 0.0;
     bool rv = this->nEvents > 0;
     for (size_t i = 0; i < this->evtsReady.size(); i++) {
         rate += this->evtsReady[i];
-        //if (this->evtsReady[i] < nEvents) rv = false;
-        std::cout << "evtsReady[" << i << "] " << evtsReady[i] << std::endl;
     }
     if (rate < nEvents) rv = false;
     rate /= evtsReady.size();
-    
-    cout << "Cycle " << curCycle+1 << endl;
-    
+
     clock_gettime(CLOCK_MONOTONIC,&cur_time);
     double time_int = (cur_time.tv_sec - last_time.tv_sec)+1e-9*(cur_time.tv_nsec - last_time.tv_nsec);
     rate /= time_int;
-    cout << "Avg rate " << rate << " Hz" << endl;
-    
-    std::cout << "nEvents " << this->nEvents << ", rv " << rv << std::endl;
+
+    if(curCycle > 0){
+	print = true;
+    }
+    if(print && path != previous_path){
+        cout << "Cycle " << curCycle << ", Trig. Rate: " << rate << ", nEV: " << this->nEvents << endl;
+	print = false;
+    }
+
+    previous_path = path;
+
     return rv;
 }

--- a/src/Dispatcher.hh
+++ b/src/Dispatcher.hh
@@ -18,10 +18,11 @@ class Dispatcher{
     virtual string NextPath() = 0;
     virtual size_t Digest(vector<Buffer*>& buffers) = 0;
     virtual void Dispatch(vector<Buffer*>& buffers) = 0;
-    virtual bool Ready();
+    virtual bool Ready(bool &print, string path);
   protected:
     size_t curCycle;
     size_t nEvents;
+    string previous_path;
     vector<size_t> evtsReady;
     struct timespec cur_time, last_time;
 };

--- a/src/LegacyHDF5Dispatcher.cc
+++ b/src/LegacyHDF5Dispatcher.cc
@@ -38,7 +38,7 @@ size_t LegacyHDF5Dispatcher::Digest(vector<Buffer*>& buffers){
 
 void LegacyHDF5Dispatcher::Dispatch(vector<Buffer*>& buffers){
     string fname = this->NextPath();
-    cout << "Saving data to " << fname << endl;
+    // cout << "Saving data to " << fname << endl;
     
     H5File file(fname, H5F_ACC_TRUNC);
     this->Initialize(file);

--- a/src/Readout.hh
+++ b/src/Readout.hh
@@ -421,14 +421,23 @@ void *readout(void *_data){
             if (cur_time.tv_sec-last_temp_time.tv_sec > temptime) {
                 pthread_mutex_lock(&iomutex);
                 last_temp_time = cur_time;
-                cout << "Temperature check..." << endl;
+                cout << "Temperature check...";
                 bool overtemp = false;
-                for (size_t i = 0; i < digitizers.size() && !stop; i++) {
+                int warning_count = 0;
+		for (size_t i = 0; i < digitizers.size() && !stop; i++) {
                     overtemp |= digitizers[i]->checkTemps(temps,84);
-                    cout << settings[i]->getIndex() << " temp: [ " << temps[0];
-                    for (size_t t = 1; t < temps.size(); t++) cout << ", " << temps[t];
-                    cout << " ]" << endl;
+                    for (size_t t = 1; t < temps.size(); t++){
+	                if(temps[t] > 65){
+		            warning_count += 1;
+			}
+	            }
                 }
+		if(warning_count > 0){
+		    cout << "WARNING: " << warning_count << " temps above 65 deg." << endl;
+		}
+		else{
+	            cout << "All below 65 deg." << endl;
+		}
                 if (overtemp) {
                     cout << "Overtemp! Aborting readout." << endl;
                     stop = true;

--- a/src/V1730.cc
+++ b/src/V1730.cc
@@ -392,14 +392,14 @@ void V1730Decoder::decode(Buffer &buf) {
 
     struct timespec cur_time;
     clock_gettime(CLOCK_MONOTONIC,&cur_time);
-    double time_int = (cur_time.tv_sec - last_decode_time.tv_sec)+1e-9*(cur_time.tv_nsec - last_decode_time.tv_nsec);
-    last_decode_time = cur_time;
+    //double time_int = (cur_time.tv_sec - last_decode_time.tv_sec)+1e-9*(cur_time.tv_nsec - last_decode_time.tv_nsec);
+    //last_decode_time = cur_time;
 
-     double nmb = decode_size / pow(1024, 2);
-     double drate = nmb / time_int;
-     cout << "\t\t data rate: "
-         << drate << " MB/s"
-         << endl;
+    // double nmb = decode_size / pow(1024, 2);
+    // double drate = nmb / time_int;
+    // cout << "\t\t data rate: "
+    //     << drate << " MB/s"
+    //     << endl;
 }
 
 size_t V1730Decoder::eventsReady() {

--- a/src/V1730.cc
+++ b/src/V1730.cc
@@ -392,14 +392,14 @@ void V1730Decoder::decode(Buffer &buf) {
 
     struct timespec cur_time;
     clock_gettime(CLOCK_MONOTONIC,&cur_time);
-    //double time_int = (cur_time.tv_sec - last_decode_time.tv_sec)+1e-9*(cur_time.tv_nsec - last_decode_time.tv_nsec);
-    //last_decode_time = cur_time;
+    double time_int = (cur_time.tv_sec - last_decode_time.tv_sec)+1e-9*(cur_time.tv_nsec - last_decode_time.tv_nsec);
+    last_decode_time = cur_time;
 
-    // double nmb = decode_size / pow(1024, 2);
-    // double drate = nmb / time_int;
-    //cout << "\t\t data rate: "
-    //     << drate << " MB/s"
-    //     << endl;
+     double nmb = decode_size / pow(1024, 2);
+     double drate = nmb / time_int;
+     cout << "\t\t data rate: "
+         << drate << " MB/s"
+         << endl;
 }
 
 size_t V1730Decoder::eventsReady() {
@@ -438,14 +438,14 @@ void V1730Decoder::writeOut(H5File &file, size_t nEvents) {
     dims[0] = nEvents;
     DataSpace space(1, dims);
 
-    std::cout << "Length counters: " << counters.size() << std::endl;
-
     DataSet counters_ds = cardgroup.createDataSet("counters", PredType::NATIVE_UINT32, space);
     counters_ds.write(counters.data(), PredType::NATIVE_UINT32);
     DataSet timetags_ds = cardgroup.createDataSet("timetags", PredType::NATIVE_UINT32, space);
     timetags_ds.write(timetags.data(), PredType::NATIVE_UINT32);
     DataSet exttimetags_ds = cardgroup.createDataSet("exttimetags", PredType::NATIVE_UINT16, space);
     exttimetags_ds.write(exttimetags.data(), PredType::NATIVE_UINT16);
+
+    std::cout << "Event count: " << counters.size() << std::endl; 
 
     for (size_t i = 0; i < nsamples.size(); i++) {
 
@@ -558,7 +558,7 @@ uint32_t* V1730Decoder::decode_board_agg(uint32_t *boardagg) {
     //const uint32_t board = (boardagg[1] >> 28) & 0xF;
     const bool fail = boardagg[1] & (1 << 26);
     if (fail){
-        throw runtime_error("board fail flag set. check with an expert.");
+        throw runtime_error("board fail flag set " + to_string(boardagg_counter));
     }
     //const uint16_t pattern = (boardagg[1] >> 8) & 0x7FFF;
     const uint16_t pattern = settings.getETTTEnabled() ? 0 : ((boardagg[1] >> 8) & 0xFFFF); // this has been changed; 0 if ETTT mode, else LVDS I/O pattern

--- a/src/V1730.cc
+++ b/src/V1730.cc
@@ -384,7 +384,7 @@ void V1730Decoder::decode(Buffer &buf) {
     vector<size_t> lastgrabbed(grabbed);
 
     decode_size = buf.fill();
-    cout << settings.getIndex() << " decoding " << decode_size << " bytes." << endl;
+    //cout << settings.getIndex() << " decoding " << decode_size << " bytes." << endl;
     uint32_t *next = (uint32_t*)buf.rptr(), *start = (uint32_t*)buf.rptr();
     while ((size_t)((next = decode_board_agg(next)) - start + 1)*4 < decode_size);
     buf.dec(decode_size);
@@ -392,25 +392,14 @@ void V1730Decoder::decode(Buffer &buf) {
 
     struct timespec cur_time;
     clock_gettime(CLOCK_MONOTONIC,&cur_time);
-    double time_int = (cur_time.tv_sec - last_decode_time.tv_sec)+1e-9*(cur_time.tv_nsec - last_decode_time.tv_nsec);
-    last_decode_time = cur_time;
+    //double time_int = (cur_time.tv_sec - last_decode_time.tv_sec)+1e-9*(cur_time.tv_nsec - last_decode_time.tv_nsec);
+    //last_decode_time = cur_time;
 
-//  for (size_t i = 0; i < idx2chan.size(); i++) {
-//      size_t nev = grabbed[i] - lastgrabbed[i];
-//      double trate = nev / time_int;
-//      cout << "\tch" << idx2chan[i]
-//           << "\tev: " << nev
-//           << " / "
-//           << trate << " Hz "
-//           << "/ "
-//           << grabbed[i] << " total"
-//           << endl;
-//  }
-    double nmb = decode_size / pow(1024, 2);
-    double drate = nmb / time_int;
-    cout << "\t\t data rate: "
-         << drate << " MB/s"
-         << endl;
+    // double nmb = decode_size / pow(1024, 2);
+    // double drate = nmb / time_int;
+    //cout << "\t\t data rate: "
+    //     << drate << " MB/s"
+    //     << endl;
 }
 
 size_t V1730Decoder::eventsReady() {
@@ -425,8 +414,6 @@ using namespace H5;
 
 //MBS: Revert to Ed's writeOut function due to issues with DigitizerData struct
 void V1730Decoder::writeOut(H5File &file, size_t nEvents) {
-
-//  cout << "\t/" << settings.getIndex() << endl;
 
     Group cardgroup = file.createGroup("/"+settings.getIndex());
 
@@ -450,6 +437,9 @@ void V1730Decoder::writeOut(H5File &file, size_t nEvents) {
     hsize_t dims[1];
     dims[0] = nEvents;
     DataSpace space(1, dims);
+
+    std::cout << "Length counters: " << counters.size() << std::endl;
+
     DataSet counters_ds = cardgroup.createDataSet("counters", PredType::NATIVE_UINT32, space);
     counters_ds.write(counters.data(), PredType::NATIVE_UINT32);
     DataSet timetags_ds = cardgroup.createDataSet("timetags", PredType::NATIVE_UINT32, space);
@@ -462,8 +452,6 @@ void V1730Decoder::writeOut(H5File &file, size_t nEvents) {
         string chname = "ch" + to_string(idx2chan[i]);
         Group group = cardgroup.createGroup(chname);
         string groupname = "/"+settings.getIndex()+"/"+chname;
-
-//      cout << "\t" << groupname << endl;
 
         Attribute offset = group.createAttribute("offset",PredType::NATIVE_UINT32,scalar);
         ival = settings.getDCOffset(idx2chan[i]);
@@ -484,12 +472,10 @@ void V1730Decoder::writeOut(H5File &file, size_t nEvents) {
         DataSpace samplespace(2, dimensions);
         DataSpace metaspace(1, dimensions);
 
-//      cout << "\t" << groupname << "/samples" << endl;
         DataSet samples_ds = file.createDataSet(groupname+"/samples", PredType::NATIVE_UINT16, samplespace);
         samples_ds.write(grabs[i], PredType::NATIVE_UINT16);
         memmove(grabs[i],grabs[i]+nEvents*nsamples[i],nsamples[i]*sizeof(uint16_t)*(grabbed[i]-nEvents));
 
-//      cout << "\t" << groupname << "/patterns" << endl;
         DataSet patterns_ds = file.createDataSet(groupname+"/patterns", PredType::NATIVE_UINT16, metaspace);
         patterns_ds.write(patterns[i], PredType::NATIVE_UINT16);
         memmove(patterns[i],patterns[i]+nEvents,sizeof(uint16_t)*(grabbed[i]-nEvents));
@@ -503,73 +489,13 @@ void V1730Decoder::writeOut(H5File &file, size_t nEvents) {
         grabbed[i] -= nEvents;
     }
 
+    timetags.clear();
+    exttimetags.clear();
+    counters.clear();
+
     dispatch_index -= nEvents;
     if (dispatch_index < 0) dispatch_index = 0;
 }
-
-//// ATM: move this to the H5 dispatcher, calls decoder's pack.
-//void V1730Decoder::writeOut(H5File &file, size_t nEvents) {
-//    DigitizerData data;
-//    pack(&data, nEvents);
-//
-//    Group cardgroup = file.createGroup("/"+settings.getIndex());
-//
-//    DataSpace scalar(0,NULL);
-//
-//    Attribute bits = cardgroup.createAttribute("bits",PredType::NATIVE_UINT32,scalar);
-//    bits.write(PredType::NATIVE_INT32, &data.bits);
-//
-//    Attribute ns_sample = cardgroup.createAttribute("ns_sample",PredType::NATIVE_DOUBLE,scalar);
-//    ns_sample.write(PredType::NATIVE_DOUBLE, &data.ns_sample);
-//
-//    Attribute samples = cardgroup.createAttribute("samples",PredType::NATIVE_UINT32,scalar);
-//    samples.write(PredType::NATIVE_UINT32, &data.samples);
-//
-//    hsize_t dims[1];
-//    dims[0] = nEvents;
-//    DataSpace space(1, dims);
-//    DataSet counters_ds = cardgroup.createDataSet("counters", PredType::NATIVE_UINT32, space);
-//    counters_ds.write(&data.counters, PredType::NATIVE_UINT32);
-//    DataSet timetags_ds = cardgroup.createDataSet("timetags", PredType::NATIVE_UINT32, space);
-//    timetags_ds.write(&data.timetags, PredType::NATIVE_UINT32);
-//    DataSet exttimetags_ds = cardgroup.createDataSet("exttimetags", PredType::NATIVE_UINT16, space);
-//    exttimetags_ds.write(&data.exttimetags, PredType::NATIVE_UINT16);
-//
-//    for (size_t i = 0; i < nsamples.size(); i++) {
-//        DigitizerData::ChannelData& ch = data.channels[i];
-//
-//        string chname = "ch" + to_string(ch.chID);
-//        Group group = cardgroup.createGroup(chname);
-//        string groupname = "/"+settings.getIndex()+"/"+chname;
-//
-//        Attribute offset = group.createAttribute("offset",PredType::NATIVE_UINT32,scalar);
-//        offset.write(PredType::NATIVE_UINT32, &ch.offset);
-//
-//        Attribute threshold = group.createAttribute("threshold",PredType::NATIVE_UINT32,scalar);
-//        threshold.write(PredType::NATIVE_UINT32, &ch.threshold);
-//
-//	Attribute dynamic_range = group.createAttribute("dynamic_range",PredType::NATIVE_DOUBLE,scalar);
-//	dynamic_range.write(PredType::NATIVE_DOUBLE, &ch.dynamic_range);
-//
-//        hsize_t dimensions[2];
-//        dimensions[0] = data.nEvents;
-//        dimensions[1] = nsamples[i];
-//
-//        DataSpace samplespace(2, dimensions);
-//        DataSpace metaspace(1, dimensions);
-//
-//        DataSet samples_ds = file.createDataSet(groupname+"/samples", PredType::NATIVE_UINT16, samplespace);
-//        samples_ds.write(&ch.samples[i], PredType::NATIVE_UINT16);
-//
-//        DataSet patterns_ds = file.createDataSet(groupname+"/patterns", PredType::NATIVE_UINT16, metaspace);
-//        patterns_ds.write(&ch.patterns[i], PredType::NATIVE_UINT16);
-//    }
-//
-//    //dispatch_index -= nEvents;
-//
-//    //if (dispatch_index < 0)
-//    //    dispatch_index = 0;
-//}
 
 uint32_t* V1730Decoder::decode_chan_agg(uint32_t *chanagg, uint32_t chn, uint16_t pattern) {
 
@@ -622,9 +548,9 @@ uint32_t* V1730Decoder::decode_board_agg(uint32_t *boardagg) {
     if (boardagg[0] == 0xFFFFFFFF) {
         boardagg++; //sometimes padded
     }
-    if ((boardagg[0] & 0xF0000000) != 0xA0000000)
+    if ((boardagg[0] & 0xF0000000) != 0xA0000000){
         throw runtime_error("Board aggregate missing tag");
-
+    }
     boardagg_counter++;
 
     uint32_t size = boardagg[0] & 0x0FFFFFFF;
@@ -641,16 +567,10 @@ uint32_t* V1730Decoder::decode_board_agg(uint32_t *boardagg) {
 
     const uint32_t counter = static_cast<uint32_t>(boardagg[2] & 0x00FFFFFF);
     const uint32_t timetag = boardagg[3];
-    std::cout << "Time Tag: " << timetag << std::endl;
     const uint16_t exttimetag = settings.getETTTEnabled() ? ((boardagg[1] >> 8) & 0xFFFF) : 0 ; // ETTT bits if ETTT mode, else 0
-    std::cout << "Ext Time Tag: " << exttimetag << std::endl;
     counters.push_back(counter);
     timetags.push_back(timetag);
     exttimetags.push_back(exttimetag);
-//  cout << "\t(LVDS & 0xFF): " << (pattern & 0xFF) << endl;
-
-    //const uint32_t count = boardagg[2] & 0x7FFFFF;
-    //const uint32_t timetag = boardagg[3];
 
     uint32_t *chans = boardagg+4;
 
@@ -666,7 +586,7 @@ uint32_t* V1730Decoder::decode_board_agg(uint32_t *boardagg) {
     return boardagg+size;
 }
 
-
+// Not used? TBK
 void V1730Decoder::pack(DigitizerData* ddd, size_t nEvents) {
     DigitizerData& data = *ddd;
     data.nEvents = nEvents;
@@ -679,9 +599,9 @@ void V1730Decoder::pack(DigitizerData* ddd, size_t nEvents) {
     memcpy(&data.timetags, timetags.data(), nEvents*sizeof(uint32_t));
     memcpy(&data.exttimetags, exttimetags.data(), nEvents*sizeof(uint16_t));
 
-    exttimetags.erase(exttimetags.begin(), exttimetags.begin() + nEvents);
-    timetags.erase(timetags.begin(), timetags.begin() + nEvents);
-    counters.erase(counters.begin(), counters.begin() + nEvents);
+    exttimetags.clear();
+    timetags.clear();
+    counters.clear();
 
     for (size_t i = 0; i < nsamples.size(); i++) {
         DigitizerData::ChannelData& ch = data.channels[i];


### PR DESCRIPTION
Work in progress. 

1) Remove or tone down a ton of spammy messages that clutter the screen.
2) Fix a bug in saving timetags & counters to the h5 file. 
3) Add standard run configurations. 